### PR TITLE
Update StatsDialog.tsx - Fix "Happening" being incorectly calculated

### DIFF
--- a/components/StatsDialog.tsx
+++ b/components/StatsDialog.tsx
@@ -58,10 +58,10 @@ export const StatsDialog = (props: Props) => {
     const averageTime = totalTime / times.length
     const sneakyGames = games.filter((x) => x.stealth).length
     const streamedGames = games.filter((x) => x.streamed).length
-    const finishedGames = games.filter((x) => x.finished && x.finished !== 'Nope').length
+    const finishedGames = games.filter((x) => x.finished && x.finished !== 'Nope' && x.finished !== 'Happening').length
     const droppedGames = games.filter((x) => x.finished && x.finished === 'Nope').length
     const backlogLength = backlog.length
-    const playedGamesLength = games.filter((x) => x.finishedDate).length
+    const playedGamesLength = games.filter((x) => x.finishedDate && x.finished !== 'Happening').length
     const backlogTime = backlog
       .map((x) => x.hltbMain)
       .filter((x) => x)


### PR DESCRIPTION
Fix for the case, where the stats are calculated incorrectly after setting the game as "Happening" using "Set upcoming" button.

Issue:
* Pressing "Set upcoming" sets finished for Happening. That makes it count towards finishedGames, however it does not set finishedDate, so it's possible achieve mathematically incorrect results like game completion being over 100%.
* Editing description with Recap sets the the date, even even though finished may still be "Happening".

Purposed solution:
* Do not count Happening in either finishedGames or playedGamesLength.